### PR TITLE
Add limit parameter to transactions endpoint

### DIFF
--- a/monzo/endpoints/transaction.py
+++ b/monzo/endpoints/transaction.py
@@ -545,7 +545,7 @@ class Transaction(Monzo):
         if before:
             data['before'] = format_date(before)
         if limit:
-            data['limit'] = max(limit, 100)
+            data['limit'] = min(limit, 100)
         path = '/transactions'
         res = auth.make_request(path=path, data=data)
         transactions = []

--- a/monzo/endpoints/transaction.py
+++ b/monzo/endpoints/transaction.py
@@ -545,7 +545,7 @@ class Transaction(Monzo):
         if before:
             data['before'] = format_date(before)
         if limit:
-            data['limit'] = limit
+            data['limit'] = max(limit, 100)
         path = '/transactions'
         res = auth.make_request(path=path, data=data)
         transactions = []

--- a/monzo/endpoints/transaction.py
+++ b/monzo/endpoints/transaction.py
@@ -517,6 +517,7 @@ class Transaction(Monzo):
             since: Optional[datetime] = None,
             before: Optional[datetime] = None,
             expand=None,
+            limit=30
     ) -> List[Transaction]:
         """
         Fetch a list of transaction.
@@ -543,6 +544,8 @@ class Transaction(Monzo):
             data['since'] = format_date(since)
         if before:
             data['before'] = format_date(before)
+        if limit:
+            data['limit'] = limit
         path = '/transactions'
         res = auth.make_request(path=path, data=data)
         transactions = []


### PR DESCRIPTION
As per https://community.monzo.com/t/changes-when-listing-with-our-api/158676 , the default limit of transactions in a response from the transactions endpoint was changed to 30. You are able to override this up to 100 by adding the 'limit' parameter.

This change allows you to choose a limit up to 100 for your response when calling Transaction.fetch.

## Summary by Sourcery

New Features:
- Added a `limit` parameter to the `Transaction.fetch` method to allow controlling the number of transactions returned.