### PR TITLE
Updated pre-commit hooks and corrected default branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   pre-commit:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - flake8-docstrings
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.14.0'
+    rev: 'v1.14.1'
     hooks:
       - id: mypy
         name: mypy

--- a/tests/mock_payloads/Transaction.json
+++ b/tests/mock_payloads/Transaction.json
@@ -1,6 +1,7 @@
 {
   "data" : {
-    "account_id" : "acc_123ABC"
+    "account_id" : "acc_123ABC",
+    "limit" : 30
   },
   "path" : "/transactions",
   "timeout" : 10,


### PR DESCRIPTION
Updated pre-commit hooks and corrected default branch as they were wrong in the git workflow files.

## Summary by Sourcery

Update pre-commit hooks and CI workflows to use main as the default branch.

Enhancements:
- Upgrade mypy pre-commit hook to v1.14.1.

CI:
- Use "main" as the default branch in CI workflows.