### PR TITLE
docs: fix Monzo API capitalization

### DIFF
--- a/docs/source/monzo_setup.rst
+++ b/docs/source/monzo_setup.rst
@@ -2,7 +2,7 @@ Monzo Setup
 =====================================
 
 As with any restricted resource on the internet, you require credentials to login.
-The Monzo APi is no different.
+The Monzo API is no different.
 
 The following tutorial will guide you through creating credentials for your account.
 


### PR DESCRIPTION
## Summary
- fix typo in monzo setup doc

## Testing
- `pre-commit run --files docs/source/monzo_setup.rst` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: fixture 'mocker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e5a0857f083248752f73613b027ce

## Summary by Sourcery

Documentation:
- Correct Monzo API capitalization in the monzo_setup.rst documentation