### PR TITLE
docs: clarify receipt module docstring

### DIFF
--- a/monzo/endpoints/receipt.py
+++ b/monzo/endpoints/receipt.py
@@ -1,4 +1,4 @@
-"""Class to manage transactions."""
+"""Class to manage receipts."""
 from __future__ import annotations
 
 from json import dumps


### PR DESCRIPTION
## Summary
- clarify receipt module docstring

## Testing
- `pytest -q` *(fails: fixture 'mocker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e5a42346c832492d275cc3685f22a