### PR TITLE
Handle unknown HTTP error codes

### DIFF
--- a/monzo/httpio.py
+++ b/monzo/httpio.py
@@ -195,7 +195,8 @@ class HttpIO(object):
             with response as fh:
                 content += fh.read().decode('utf-8')
         except HTTPError as error:
-            raise MONZO_ERROR_MAP[error.code]() from error
+            exception_cls = MONZO_ERROR_MAP.get(error.code, MonzoGeneralError)
+            raise exception_cls() from error
         return {
             'code': response.code,
             'headers': response.headers,

--- a/tests/test_httpio_errors.py
+++ b/tests/test_httpio_errors.py
@@ -1,0 +1,14 @@
+import pytest
+from urllib.error import HTTPError
+from unittest.mock import patch
+
+from monzo.httpio import HttpIO
+from monzo.exceptions import MonzoGeneralError
+
+
+def test_unknown_status_code_raises_monzogeneralerror():
+    http = HttpIO('https://example.com')
+    error = HTTPError(url='https://example.com/test', code=418, msg='teapot', hdrs=None, fp=None)
+    with patch('monzo.httpio.urlopen', side_effect=error):
+        with pytest.raises(MonzoGeneralError):
+            http.get('/test')

--- a/tests/test_httpio_errors.py
+++ b/tests/test_httpio_errors.py
@@ -1,6 +1,7 @@
-import pytest
-from urllib.error import HTTPError
 from unittest.mock import patch
+from urllib.error import HTTPError
+
+import pytest
 
 from monzo.exceptions import MonzoGeneralError
 from monzo.httpio import HttpIO

--- a/tests/test_httpio_errors.py
+++ b/tests/test_httpio_errors.py
@@ -2,8 +2,8 @@ import pytest
 from urllib.error import HTTPError
 from unittest.mock import patch
 
-from monzo.httpio import HttpIO
 from monzo.exceptions import MonzoGeneralError
+from monzo.httpio import HttpIO
 
 
 def test_unknown_status_code_raises_monzogeneralerror():


### PR DESCRIPTION
## Summary
- avoid KeyError for unexpected HTTP responses in HttpIO
- add regression test for unhandled status codes

## Testing
- `pytest -q` *(fails: fixture 'mocker' not found)*
- `pytest tests/test_httpio_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e59275398832488df20e590145ae8

## Summary by Sourcery

Handle unknown HTTP status codes without raising KeyError by defaulting to MonzoGeneralError and add a regression test

Bug Fixes:
- Map unexpected HTTP error codes to MonzoGeneralError to avoid KeyError

Tests:
- Add regression test to verify that unknown HTTP status codes raise MonzoGeneralError