### PR TITLE
Updated zizmor config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+---
 github: petermcd

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,4 @@
+---
 name: "CodeQL"
 
 on:
@@ -10,27 +11,38 @@ on:
   schedule:
     - cron: '21 1 * * 2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # required for actions/checkout to work.
+      contents: read # required for CodeQL to analyze the repository's code.
+      security-events: write # required for CodeQL to create security events.
+
     strategy:
       fail-fast: false
       matrix:
         language:
           - 'python'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23
         with:
           languages: ${{ matrix.language }}
+
       - name: Autobuild
         uses: github/codeql-action/autobuild@192325c86100d080feab897ff886c34abd4c83a3
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23
+        uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3
         with:
           languages: ${{ matrix.language }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+---
 name: Publish to PyPI
 
 on:
@@ -5,24 +6,32 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # Allows actions/checkout to access the GitHub token for authentication.
+
 jobs:
   pypi-publish:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
           - "3.10"
-    permissions:
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: false
       - name: UV Build
         run: uv build
       - name: Publish package distributions to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write # Allows actions/checkout to access the GitHub token for authentication.
+  contents: read # Required by actions/checkout to read the repository contents.
+  id-token: write # Required for OIDC authentication when publishing to PyPI.
 
 jobs:
   pypi-publish:

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -18,7 +18,6 @@ env:
   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
 permissions:
-  id-token: write # Allows actions/checkout to access the GitHub token for authentication.
   contents: read # Allows actions/checkout to read the repository contents.
 
 jobs:
@@ -54,5 +53,5 @@ jobs:
       - name: Run SonarQube
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         env:
-          SONAR_TOKEN: $SONAR_TOKEN
-          SONAR_HOST_URL: $SONAR_HOST_URL
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -1,3 +1,4 @@
+---
 name: UV
 
 on:
@@ -8,20 +9,32 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+permissions:
+  id-token: write # Allows actions/checkout to access the GitHub token for authentication.
+  contents: read # Allows actions/checkout to read the repository contents.
+
 jobs:
   uv:
     name: python
     runs-on: ubuntu-latest
-    permissions: read-all
     strategy:
       matrix:
         python-version:
-          - "3.11"
+          - "3.10"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
         with:
@@ -41,5 +54,5 @@ jobs:
       - name: Run SonarQube
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: $SONAR_TOKEN
+          SONAR_HOST_URL: $SONAR_HOST_URL

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,3 +1,4 @@
+---
 name: Zizmor
 
 on:
@@ -8,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -15,9 +20,9 @@ jobs:
     name: Zizmor
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # Allows zizmor to write security events.
+      contents: read # Required for private repositories.
+      actions: read # Required for private repositories.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -26,4 +31,6 @@ jobs:
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8
         with:
-          inputs: .github/
+          inputs: |
+            .github/*.yml
+            .github/workflows/*.yml


### PR DESCRIPTION
Enhanced zizmor config

## Summary by Sourcery

Align GitHub workflows and zizmor configuration for security scanning, publishing, and funding metadata.

Enhancements:
- Add concurrency groups to GitHub workflows to cancel in-progress runs on the same ref.
- Refine zizmor inputs to scan only YAML workflow files under .github and .github/workflows.
- Standardize workflow permissions and checkout configuration, including disabling persisted credentials and documenting required scopes.
- Update UV workflow Python version matrix and centralize SonarQube configuration via environment variables.
- Disable caching in the publish workflow uv setup and add explicit job naming.

Build:
- Add YAML document headers to GitHub workflows and funding config for consistency.