### PR TITLE
Added coverage path for sq

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.projectKey=petermcd_monzo-api_04a97896-4fdc-4f19-9741-cfbf67fe58c1
 sonar.sources=./monzo
+sonar.python.coverage.reportPaths=./coverage.xml


### PR DESCRIPTION
Added path to coverage report to allow sq analysis

## Summary by Sourcery

Build:
- Add sonar.python.coverage.reportPaths to point SonarQube at the coverage.xml report for analysis.