### PR TITLE
Resolve vulnerable dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ documentation = "https://monzo-api.readthedocs.io"
 
 [dependency-groups]
 dev = [
+    "idna>=3.16", # To resolve security vulnerabilities in dependencies pip-audit
     "pygments>=2.20.0", # To resolve security vulnerabilities in dependencies pytest sphinx
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
@@ -37,6 +38,7 @@ dev = [
     "sphinx-rtd-theme>=3.1.0",
     "troml>=0.4.1",
     "ty>=0.0.29",
+    "urllib3>=2.7.0", # To resolve security vulnerabilities in dependencies pip-audit
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Monzo-API"
-version = "1.2.3"
+version = "1.2.4"
 authors = [{ name = "Peter McDonald", email = "git@petermcdonald.co.uk"}]
 description = "Package to interact with the API provided by Monzo bank"
 keywords = ["monzo", "bank", "api"]

--- a/uv.lock
+++ b/uv.lock
@@ -201,11 +201,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -329,6 +329,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "idna" },
     { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -338,12 +339,14 @@ dev = [
     { name = "sphinx-rtd-theme" },
     { name = "troml" },
     { name = "ty" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "idna", specifier = ">=3.16" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -353,6 +356,7 @@ dev = [
     { name = "sphinx-rtd-theme", specifier = ">=3.1.0" },
     { name = "troml", specifier = ">=0.4.1" },
     { name = "ty", specifier = ">=0.0.29" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -686,9 +690,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
Update vulnerable dev dependencies caused by pip-audit (ironically)

## Summary by Sourcery

Update development dependency constraints to address security vulnerabilities reported in transitive tools.

Build:
- Bump dev-only idna and urllib3 minimum versions to resolve security issues in pip-audit’s dependency chain.
- Raise minimum pygments version used by pytest and Sphinx-related tooling to a non-vulnerable release.